### PR TITLE
update to 5.1.0 and switch to alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
 # Centos ha-bridge
 
-# Version 5.0
+# Version 5.1.0
 
-FROM centos:centos7
+FROM openjdk:8-alpine
 MAINTAINER Tobias Sgoff
 
-RUN yum -y install java-1.8.0-openjdk wget unzip
-RUN mkdir /bridge/ && cd $_ && \
+RUN apk add --no-cache curl
+RUN mkdir /bridge/ && cd /bridge && \
     UR="https://github.com/bwssytems/ha-bridge" ; \
     LV=`curl -s $UR/releases/latest |cut -d'v' -f2|cut -d'"' -f1` ; \
     wget $UR/releases/download/v${LV}/ha-bridge-${LV}.jar -Oha-bridge.jar
-RUN echo '#!/bin/bash' > /bridge/init.sh ; \
+RUN echo '#!/bin/ash' > /bridge/init.sh ; \
     echo java -jar \$PORT \$KEY \$CONFIG \$IP \$GARDEN /bridge/ha-bridge.jar >> /bridge/init.sh
 RUN chmod +x /bridge/init.sh
 


### PR DESCRIPTION
- alpine version is around 100mb, while centos version was
  400mb+